### PR TITLE
Fix typo: Causes an error when `resp` is false (#1260)

### DIFF
--- a/service/launcher.lua
+++ b/service/launcher.lua
@@ -32,9 +32,9 @@ local function list_srv(ti, fmt_func, ...)
 		sessions[r] = addr
 	end
 	for req, resp in req:select(ti) do
-		local stat = resp[1]
 		local addr = req[1]
 		if resp then
+			local stat = resp[1]
 			list[skynet.address(addr)] = fmt_func(stat, addr)
 		else
 			list[skynet.address(addr)] = fmt_func("ERROR", addr)


### PR DESCRIPTION
Co-authored-by: zhouyan <zhouyan@onemt.com.cn>