### PR TITLE
socket.onclose() (#1364)

### DIFF
--- a/lualib/skynet/socket.lua
+++ b/lualib/skynet/socket.lua
@@ -123,6 +123,9 @@ socket_message[3] = function(id)
 	end
 	s.connected = false
 	wakeup(s)
+	if s.on_close then
+		s.on_close(id)
+	end
 end
 
 -- SKYNET_SOCKET_TYPE_ACCEPT = 4
@@ -483,6 +486,12 @@ function socket.warning(id, callback)
 	local obj = socket_pool[id]
 	assert(obj)
 	obj.on_warning = callback
+end
+
+function socket.onclose(id, callback)
+	local obj = socket_pool[id]
+	assert(obj)
+	obj.on_close = callback
 end
 
 return socket

--- a/skynet-src/socket_server.h
+++ b/skynet-src/socket_server.h
@@ -13,7 +13,10 @@
 #define SOCKET_EXIT 5
 #define SOCKET_UDP 6
 #define SOCKET_WARNING 7
-#define SOCKET_RST 8 // Only for internal use
+
+// Only for internal use
+#define SOCKET_RST 8
+#define SOCKET_MORE 9
 
 struct socket_server;
 


### PR DESCRIPTION
* Add socket.onclose() and close socket immediately when socket channel closed by peer

* Revert read_socket(), Add SOCKET_MORE, See #1358

* remove warning log , because it's not a rare case any more. See #1358